### PR TITLE
Prevent reset scaling factor to zero.

### DIFF
--- a/contracts/token/YAM.sol
+++ b/contracts/token/YAM.sol
@@ -427,6 +427,9 @@ contract YAMToken is YAMGovernanceToken {
             }
         }
 
+        // Prevent reset to zero.
+        require(yamsScalingFactor > 0, "scaling factor is zero");
+        
         // update total supply, correctly
         totalSupply = _yamToFragment(initSupply);
 


### PR DESCRIPTION
If the scaling factor is reset to zero (and total supply as result), it cannot be set up back and the token will be lost as a result.

_Note_: Ampleforth's rebase function cannot lead to reset total supply to zero.