### PR TITLE
Add ability for arbiter to close a metapool

### DIFF
--- a/contracts/tests/Umbrella/UmbrellaMetaPool.sol
+++ b/contracts/tests/Umbrella/UmbrellaMetaPool.sol
@@ -302,6 +302,8 @@ contract UmbrellaMetaPool is CoverPricing {
     /// @notice Whether the pool has an arbiter
     bool public arbSet;
     bool public accepted;
+    /// @notice Whether buying insurance is disabled
+    bool public buyDisabled;
 
     // === Pool storage ===
     /// @notice List of protected concepts, i.e. ["Dydx", "Compound", "Aave"]
@@ -580,6 +582,8 @@ contract UmbrellaMetaPool is CoverPricing {
         payable
         hasArbiter
     {
+        require(!buyDisabled, "buy: buyDisabled");
+
         // check deadline
         require(block.timestamp <= deadline,               "buy:!deadline");
         require(   conceptIndex <  coveredConcepts.length, "buy:!conceptIndex");
@@ -1033,6 +1037,14 @@ contract UmbrellaMetaPool is CoverPricing {
         onlyArbiter
     {
         arbSet = false;
+    }
+
+    ///@notice Disables buying insurance, providing coverage is still allowed
+    function _disableBuy() 
+        public 
+        onlyArbiter
+    {
+        buyDisabled = true;
     }
 
     // ============ Creator Functions ============

--- a/contracts/tests/Umbrella/UmbrellaMetaPool.t.sol
+++ b/contracts/tests/Umbrella/UmbrellaMetaPool.t.sol
@@ -712,6 +712,33 @@ contract Prop3 is YAMv3Test {
         continue_pool();
     }
 
+    function test_ycp_disable_buy() public {
+        // test setup
+        initialize_pool();
+        yamhelper.write_balanceOf(DAI, me, 200*10**18);
+        IERC20(DAI).approve(address(pool), uint(-1));
+        pool.provideCoverage(100*10**18);
+        pool._disableBuy();
+
+        // buy protection should be disabled
+        expect_revert_with(
+          address(pool),
+          "buyProtection(uint8,uint128,uint128,uint128,uint256)",
+          abi.encode(
+            30,
+            1,
+            1,
+            1,
+            block.timestamp + 10
+          ),
+          "buy: buyDisabled"
+        );
+
+        // providing liquidity should still work
+        pool.provideCoverage(100*10**18);
+        assertEq(uint256(pool.reserves()), 200*10**18, "reserves");
+    }
+
     function set_settling() public {
       yamhelper.ff(2);
       pool._setSettling(0, uint32(block.timestamp - 1), false);


### PR DESCRIPTION
> A function that can only be called by the arbiter which permanently disables protection purchasing from the metapool
> Must leave the pool unchanged aside from purchase being disabled - still allow providing