### PR TITLE
Allow passing in test name argument to run test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ out
 scripts/out/dapp.sol.json
 out2
 makepad_*
+nix.sh
 
 #Added by cargo
 

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ To run tests, install Nix and dapptools:
 
 ```
 $ curl -L https://nixos.org/nix/install > nix.sh
-$ nix-env -iA dapp hevm -f https://github.com/dapphub/dapptools/tarball/master -v
+$ nix-env -iA dapp seth hevm -f https://github.com/dapphub/dapptools/tarball/master -v
 ```
 
 Running tests:
 
 ```
 $ export ETH_RPC_URL=http://localhost:8545 # mainnet node
-$ ./scripts/dapp-test.sh
+$ ./scripts/dapp-test.sh [test_name]
 ```
 
 ### Attributions

--- a/scripts/dapp-test.sh
+++ b/scripts/dapp-test.sh
@@ -6,6 +6,13 @@ oops() {
     exit 1
 }
 
+if [ -z "$1" ]
+  then
+    echo "Missing test name argument"
+    printf "Correct usage: ./scripts/dapp-test.sh [test_name]\n\n"
+    exit 1
+fi
+
 export ETH_RPC_URL="https://fee7372b6e224441b747bf1fde15b2bd.eth.rpc.rivet.cloud/"
 
 export DAPP_SRC=./contracts
@@ -22,4 +29,4 @@ export DAPP_TEST_ORIGIN="0x683A78bA1f6b25E29fbBC9Cd1BFA29A51520De84"
 export DAPP_TEST_CHAINED=99
 export DAPP_TEST_ADDRESS="0x683A78bA1f6b25E29fbBC9Cd1BFA29A51520De84"
 printf 'Running test for address %s\n' "$DAPP_TEST_ADDRESS"
-LANG=C.UTF-8 dapp test --rpc-url "https://fee7372b6e224441b747bf1fde15b2bd.eth.rpc.rivet.cloud/" -v --match test_onchain_prop_12
+LANG=C.UTF-8 dapp test --rpc-url "https://fee7372b6e224441b747bf1fde15b2bd.eth.rpc.rivet.cloud/" -v --match "$1"


### PR DESCRIPTION
- Updated ./scripts/dapp-test.sh to take in an argument to run a specific test
- Update README.md to adjust to this change (+ added `seth` to list of package to install)
- Updated .gitignore to ignore nix.sh file